### PR TITLE
Change the way to match handler to type

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -48,5 +48,6 @@ jobs:
       run: |
         python -m pip install --upgrade twine
         python setup.py sdist
-        sh tag.sh $(ls dist|sed -E "s/^smart-arg-(.*)\.tar\.gz$/v\1/")
+        export VERSION="(ls dist|sed -E "s/^smart-arg-(.*)\.tar\.gz$/v\1/")"
+        sh tag.sh $VERSION
         twine upload dist/* --verbose

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,9 @@
 LICENSE
 =======
-BSD 2-CLAUSE LICENSE
-Copyright 2020 LinkedIn Corporation
-All Rights Reserved.
+    BSD 2-CLAUSE LICENSE
+    Copyright 2020 LinkedIn Corporation
+    All Rights Reserved.
+
 Redistribution and use in source and binary forms, with or
 without modification, are permitted provided that the following
 conditions are met:

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -91,7 +91,8 @@ is defined in source code `PrimitiveHandlerAddon`. A user can pass in the custom
 other than primitive ones such as `List`, `Set`, `Dict`, `Tuple`, etc.
 
 ```python
-from typing import NamedTuple
+from math import sqrt
+from typing import NamedTuple, Any, Type
 
 from smart_arg import PrimitiveHandlerAddon, TypeHandler, custom_arg_suite
 
@@ -99,18 +100,27 @@ from smart_arg import PrimitiveHandlerAddon, TypeHandler, custom_arg_suite
 # overwrite int primitive type handling by squaring it
 class IntHandlerAddon(PrimitiveHandlerAddon):
     @staticmethod
-    def build_primitive(arg_type, kwargs):
-        if arg_type is int:
-            kwargs.type = lambda s: int(s) ** 2
+    def build_type(arg_type) -> Any:
+        return lambda s: int(s) ** 2
 
-    handled_types = [int]
+    @staticmethod
+    def build_str(arg) -> str:
+        return str(int(sqrt(arg)))
 
+    @staticmethod
+    def handles(t: Type) -> bool:
+        return t == int
 
 class IntTypeHandler(TypeHandler):
-    def _build_common(self, kwargs, field_meta):
+    def _build_common(self, kwargs, field_meta) -> None:
+        super()._build_common(kwargs, field_meta)
         kwargs.help = '(int, squared)'
 
-    handled_types = [int]
+    def _build_other(self, kwargs, arg_type) -> None:
+        kwargs.type = self.primitive_addons[0].build_type(arg_type)
+
+    def handles(self, t: Type) -> bool:
+        return t == int
 
 
 @custom_arg_suite(primitive_handler_addons=[IntHandlerAddon], type_handlers=[IntTypeHandler])


### PR DESCRIPTION
Instead of a dict lookup, just iterate through the handlers to see which handles the targeted type.
We have very limited handlers so shouldn't be much performance loss if there is any but it's much more flexible to match the handler now.
